### PR TITLE
Updated instructions to require Julia 1.1

### DIFF
--- a/RTS-dispatch.ipynb
+++ b/RTS-dispatch.ipynb
@@ -55,7 +55,7 @@
     }
    },
    "source": [
-    "This notebook expects Julia 0.7 and uses the environment setup in the subfolder SimplePCM_env. You can setup the environment with the next two cells.\n",
+    "This notebook requires Julia 1.1 and uses the environment setup in the subfolder `env`. You can setup the environment with the next two cells.\n",
     "\n",
     "The environment should look like:\n",
     "```julia\n",

--- a/System Modeling and Dispatching.ipynb
+++ b/System Modeling and Dispatching.ipynb
@@ -46,7 +46,7 @@
    "source": [
     "## Environment and packages\n",
     "\n",
-    "The examples in this notebook depend upon a specific set of package releases as defined in the `SMD_env` folder. Also, the build process of `PowerSimulations.jl` retrieves a few sample datafiles that will be used for demonstration. The following steps outline loading the environment, building `PowerSimulations.jl`, and loading the required packages."
+    "The examples in this notebook depend upon Julia 1.1 and a specific set of package releases as defined in the `env` folder. Also, the build process of `PowerSimulations.jl` retrieves a few sample datafiles that will be used for demonstration. The following steps outline loading the environment, building `PowerSimulations.jl`, and loading the required packages."
    ]
   },
   {


### PR DESCRIPTION
Julia 1.1 is needed because `isnothing` first appears in the `base` package there.

The notebook also incorrectly referred to `SimplePCM_env` and `SMD_env` instead of just `env`.